### PR TITLE
humanfriendly 10.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,9 @@ requirements:
     - wheel
   run:
     - python
-    - pyreadline  # [win]
     - monotonic  # [py2k]
+    - pyreadline  # [win and py<38]
+    - pyreadline3  # [win and py>=38]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "9.2" %}
+{% set version = "10.0" %}
 
 package:
   name: humanfriendly
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/h/humanfriendly/humanfriendly-{{ version }}.tar.gz
-  sha256: f7dba53ac7935fd0b4a2fc9a29e316ddd9ea135fb3052d3d0279d10c18ff9c48
+  sha256: 6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc
 
 build:
   number: 0


### PR DESCRIPTION
Update humanfriendly to 10.0

Version change: bump version number from 9.2 to 10.0 (Major version bump!)
Bug Tracker: new open issues https://github.com/xolox/python-humanfriendly/issues
Upstream Changelog: https://github.com/xolox/python-humanfriendly/blob/master/CHANGELOG.rst
Upstream setup.py:  https://github.com/xolox/python-humanfriendly/blob/10.0/setup.py
The package humanfriendly is mentioned inside the packages:
capturer | coloredlogs | 

Actions:
1. Add `pyreadline3  # [win and py>=38]`

Result:
- all-succeeded